### PR TITLE
Add headings hierarchy

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,4 +34,5 @@ Suggests:
 Remotes: 
     Merck/simtrial,
     Merck/gsDesign2
+Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2

--- a/R/gs_info_wlr.R
+++ b/R/gs_info_wlr.R
@@ -179,13 +179,13 @@ gs_sigma2_wlr <- function(arm0,
 #' @param events Targeted minimum events at each analysis
 #' @param analysisTimes Targeted minimum study duration at each analysis
 #' @param weight weight of weighted log rank test
-#'               * "1"=unweighted,
-#'               * "n"=Gehan-Breslow,
-#'               * "sqrtN"=Tarone-Ware,
-#'               * "FH_p[a]_q[b]"= Fleming-Harrington with p=a and q=b
+#' - `"1"`=unweighted,
+#' - `"n"`=Gehan-Breslow,
+#' - `"sqrtN"`=Tarone-Ware,
+#' - `"FH_p[a]_q[b]"`= Fleming-Harrington with p=a and q=b
 #' @param approx approximate estimation method for Z statistics
-#'               * "event driven" = only work under propotional hazard model with log rank test
-#'               * "asymptotic"
+#' - `"event driven"` = only work under proportional hazard model with log rank test
+#' - `"asymptotic"`
 #'
 #' @return a \code{tibble} with columns \code{Analysis, Time, N, Events, AHR, delta, sigma2, theta, info, info0.}
 #' \code{info, info0} contains statistical information under H1, H0, respectively.

--- a/man/ahr_blinded.Rd
+++ b/man/ahr_blinded.Rd
@@ -26,12 +26,12 @@ specified.}
 }
 \value{
 A \code{tibble} with one row containing
-`AHR` blinded average hazard ratio based on assumed period-specific hazard ratios input in `failRates`
+\code{AHR} blinded average hazard ratio based on assumed period-specific hazard ratios input in \code{failRates}
 and observed events in the corresponding intervals
-`Events` total observed number of events, `info` statistical information based on Schoenfeld approximation,
-and info0 (information under related null hypothesis) for each value of `totalDuration` input;
-if `simple=FALSE`, `Stratum` and `t` (beginning of each constant HR period) are also returned
-and `HR` is returned instead of `AHR`
+\code{Events} total observed number of events, \code{info} statistical information based on Schoenfeld approximation,
+and info0 (information under related null hypothesis) for each value of \code{totalDuration} input;
+if \code{simple=FALSE}, \code{Stratum} and \code{t} (beginning of each constant HR period) are also returned
+and \code{HR} is returned instead of \code{AHR}
 }
 \description{
 Based on blinded data and assumed hazard ratios in different intervals, compute

--- a/man/gs_bound.Rd
+++ b/man/gs_bound.Rd
@@ -35,14 +35,14 @@ gs_bound(
 
 \item{algorithm}{ an object of class \code{\link[mvtnorm]{GenzBretz}},
                     \code{\link[mvtnorm]{Miwa}} or \code{\link[mvtnorm]{TVPACK}}
-                    specifying both the algorithm to be used as well as 
+                    specifying both the algorithm to be used as well as
                     the associated hyper parameters.}
 
 \item{alpha_bound}{logical value to indicate if alpha is Type I error or upper bound. Default is FALSE.}
 
 \item{beta_bound}{logical value to indicate if beta is Type II error or lower bound. Default is FALSE.}
 
-\item{...}{additional parameters transfer to `mvtnorm::pmvnorm`}
+\item{...}{additional parameters transfer to \code{mvtnorm::pmvnorm}}
 }
 \description{
 Lower and Upper Bound of Group Sequential Design

--- a/man/gs_design_combo.Rd
+++ b/man/gs_design_combo.Rd
@@ -47,12 +47,12 @@ Refer examples for its data structure.}
 
 \item{algorithm}{ an object of class \code{\link[mvtnorm]{GenzBretz}},
                     \code{\link[mvtnorm]{Miwa}} or \code{\link[mvtnorm]{TVPACK}}
-                    specifying both the algorithm to be used as well as 
+                    specifying both the algorithm to be used as well as
                     the associated hyper parameters.}
 
 \item{n_upper_bound}{a numeric value of upper limit of sample size}
 
-\item{...}{additional parameters transfer to `mvtnorm::pmvnorm`}
+\item{...}{additional parameters transfer to \code{mvtnorm::pmvnorm}}
 }
 \description{
 Group sequential design using MaxCombo test under non-proportional hazards

--- a/man/gs_design_wlr.Rd
+++ b/man/gs_design_wlr.Rd
@@ -37,14 +37,18 @@ gs_design_wlr(
 \item{ratio}{Experimental:Control randomization ratio (not yet implemented)}
 
 \item{weight}{weight of weighted log rank test
-* "1"=unweighted,
-* "n"=Gehan-Breslow,
-* "sqrtN"=Tarone-Ware,
-* "FH_p[a]_q[b]"= Fleming-Harrington with p=a and q=b}
+\itemize{
+\item \code{"1"}=unweighted,
+\item \code{"n"}=Gehan-Breslow,
+\item \code{"sqrtN"}=Tarone-Ware,
+\item \code{"FH_p[a]_q[b]"}= Fleming-Harrington with p=a and q=b
+}}
 
 \item{approx}{approximate estimation method for Z statistics
-* "event driven" = only work under propotional hazard model with log rank test
-* "asymptotic"}
+\itemize{
+\item \code{"event driven"} = only work under proportional hazard model with log rank test
+\item \code{"asymptotic"}
+}}
 
 \item{alpha}{One-sided Type I error}
 

--- a/man/gs_info_wlr.Rd
+++ b/man/gs_info_wlr.Rd
@@ -28,14 +28,18 @@ gs_info_wlr(
 \item{analysisTimes}{Targeted minimum study duration at each analysis}
 
 \item{weight}{weight of weighted log rank test
-* "1"=unweighted,
-* "n"=Gehan-Breslow,
-* "sqrtN"=Tarone-Ware,
-* "FH_p[a]_q[b]"= Fleming-Harrington with p=a and q=b}
+\itemize{
+\item \code{"1"}=unweighted,
+\item \code{"n"}=Gehan-Breslow,
+\item \code{"sqrtN"}=Tarone-Ware,
+\item \code{"FH_p[a]_q[b]"}= Fleming-Harrington with p=a and q=b
+}}
 
 \item{approx}{approximate estimation method for Z statistics
-* "event driven" = only work under propotional hazard model with log rank test
-* "asymptotic"}
+\itemize{
+\item \code{"event driven"} = only work under proportional hazard model with log rank test
+\item \code{"asymptotic"}
+}}
 }
 \value{
 a \code{tibble} with columns \code{Analysis, Time, N, Events, AHR, delta, sigma2, theta, info, info0.}

--- a/man/gs_power_combo.Rd
+++ b/man/gs_power_combo.Rd
@@ -40,10 +40,10 @@ Refer examples for its data structure.}
 
 \item{algorithm}{ an object of class \code{\link[mvtnorm]{GenzBretz}},
                     \code{\link[mvtnorm]{Miwa}} or \code{\link[mvtnorm]{TVPACK}}
-                    specifying both the algorithm to be used as well as 
+                    specifying both the algorithm to be used as well as
                     the associated hyper parameters.}
 
-\item{...}{additional parameters transfer to `mvtnorm::pmvnorm`}
+\item{...}{additional parameters transfer to \code{mvtnorm::pmvnorm}}
 }
 \description{
 Group sequential design power using MaxCombo test under non-proportional hazards

--- a/man/gs_power_wlr.Rd
+++ b/man/gs_power_wlr.Rd
@@ -34,14 +34,18 @@ gs_power_wlr(
 \item{ratio}{Experimental:Control randomization ratio (not yet implemented)}
 
 \item{weight}{weight of weighted log rank test
-* "1"=unweighted,
-* "n"=Gehan-Breslow,
-* "sqrtN"=Tarone-Ware,
-* "FH_p[a]_q[b]"= Fleming-Harrington with p=a and q=b}
+\itemize{
+\item \code{"1"}=unweighted,
+\item \code{"n"}=Gehan-Breslow,
+\item \code{"sqrtN"}=Tarone-Ware,
+\item \code{"FH_p[a]_q[b]"}= Fleming-Harrington with p=a and q=b
+}}
 
 \item{approx}{approximate estimation method for Z statistics
-* "event driven" = only work under propotional hazard model with log rank test
-* "asymptotic"}
+\itemize{
+\item \code{"event driven"} = only work under proportional hazard model with log rank test
+\item \code{"asymptotic"}
+}}
 
 \item{events}{Targeted events at each analysis}
 

--- a/man/gs_prob.Rd
+++ b/man/gs_prob.Rd
@@ -22,7 +22,7 @@ gs_prob(theta, upper = gs_b, lower = gs_b, upar, lpar, info, r = 18)
 \item{r}{Integer, at least 2; default of 18 recommended by Jennison and Turnbull}
 }
 \value{
-A `tibble` with a row for each finite bound and analysis containing the following variables:
+A \code{tibble} with a row for each finite bound and analysis containing the following variables:
 Analysis analysis number
 Bound Upper (efficacy) or Lower (futility)
 Z Z-value at bound

--- a/man/gs_prob_combo.Rd
+++ b/man/gs_prob_combo.Rd
@@ -27,10 +27,10 @@ gs_prob_combo(
 
 \item{algorithm}{ an object of class \code{\link[mvtnorm]{GenzBretz}},
                     \code{\link[mvtnorm]{Miwa}} or \code{\link[mvtnorm]{TVPACK}}
-                    specifying both the algorithm to be used as well as 
+                    specifying both the algorithm to be used as well as
                     the associated hyper parameters.}
 
-\item{...}{additional parameters transfer to `mvtnorm::pmvnorm`}
+\item{...}{additional parameters transfer to \code{mvtnorm::pmvnorm}}
 }
 \description{
 MaxCombo Group sequential boundary crossing probabilities

--- a/man/gs_spending_combo.Rd
+++ b/man/gs_spending_combo.Rd
@@ -16,7 +16,7 @@ gs_spending_combo(par = NULL, info = NULL, ...)
 
 \item{info}{statistical information at all analyses, at least up to analysis k}
 
-\item{...}{additional parameters transfered to `par$sf`.}
+\item{...}{additional parameters transfered to \code{par$sf}.}
 }
 \description{
 Derive spending bound for MaxCombo group sequential boundary

--- a/man/gsdmvn.Rd
+++ b/man/gsdmvn.Rd
@@ -12,16 +12,20 @@ generalizing the theory presented by Jennison and Turnbull (2000) to cases with
 non-homogeneous treatment effect over time.
 The primary application for this is group sequential design under the assumption of non-proportional hazards.
 The gsdmvn package has 4 types of functions
-1) support for asymptotic normal distribution computation,
-2) support for group sequential bound derivation, and
-3) support for design and power calculations.
-4) applications to designs for survival analysis under non-proportional hazards assumptions.
+\enumerate{
+\item support for asymptotic normal distribution computation,
+\item support for group sequential bound derivation, and
+\item support for design and power calculations.
+\item applications to designs for survival analysis under non-proportional hazards assumptions.
+}
 }
 \details{
 In addition to the above function categeories, vignettes show how to implement
-1) design for a binomial endpoint as an example of how to extend the package to other endpoint types,
-2) the extensive capabilities around group sequential boundary calculations,
+\enumerate{
+\item design for a binomial endpoint as an example of how to extend the package to other endpoint types,
+\item the extensive capabilities around group sequential boundary calculations,
 including enabling capabilities not in the gsDesign package.
+}
 }
 \section{gsdmvn functions}{
 

--- a/man/pmvnorm_combo.Rd
+++ b/man/pmvnorm_combo.Rd
@@ -27,10 +27,10 @@ pmvnorm_combo(
 
 \item{algorithm}{ an object of class \code{\link[mvtnorm]{GenzBretz}},
                     \code{\link[mvtnorm]{Miwa}} or \code{\link[mvtnorm]{TVPACK}}
-                    specifying both the algorithm to be used as well as 
+                    specifying both the algorithm to be used as well as
                     the associated hyper parameters.}
 
-\item{...}{additional parameters transfer to `mvtnorm::pmvnorm`}
+\item{...}{additional parameters transfer to \code{mvtnorm::pmvnorm}}
 }
 \description{
 Computes the distribution function of the multivariate normal distribution
@@ -42,5 +42,5 @@ Here i is a group indicator and j is a within group statistics indicator.
 Let G_i = max({Z_ij}) for all test within one group.
 This program are calculating the probability
 
-  $$Pr( lower < max(G) < upper )$$
+$$Pr( lower < max(G) < upper )$$
 }

--- a/man/wlr_weight.Rd
+++ b/man/wlr_weight.Rd
@@ -16,9 +16,9 @@ wlr_weight_n(x, arm0, arm1, power = 1)
 \arguments{
 \item{x}{analysis time}
 
-\item{arm0}{an "arm" object defined in `npsurvSS` package}
+\item{arm0}{an "arm" object defined in \code{npsurvSS} package}
 
-\item{arm1}{an "arm" object defined in `npsurvSS` package}
+\item{arm1}{an "arm" object defined in \code{npsurvSS} package}
 
 \item{rho}{A scalar parameter that controls the type of test}
 
@@ -29,9 +29,11 @@ wlr_weight_n(x, arm0, arm1, power = 1)
 \item{power}{A scalar parameter that controls the power of the weight function}
 }
 \description{
-* `wlr_weight_fh` is Fleming-Harriongton, FH(rho, gamma) weight function.
-* `wlr_weight_1`  is constant for log rank test
-* `wlr_weight_power` is Gehan-Breslow and Tarone-Ware weight function.
+\itemize{
+\item \code{wlr_weight_fh} is Fleming-Harriongton, FH(rho, gamma) weight function.
+\item \code{wlr_weight_1}  is constant for log rank test
+\item \code{wlr_weight_power} is Gehan-Breslow and Tarone-Ware weight function.
+}
 }
 \section{Specification}{
 

--- a/vignettes/DesignWithSpending.Rmd
+++ b/vignettes/DesignWithSpending.Rmd
@@ -13,13 +13,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
-library(gsdmvn)
-library(dplyr)
-library(tibble)
-library(gsDesign)
-library(gsDesign2)
 ```
-
 
 ## Overview
 
@@ -30,18 +24,28 @@ We are primarily concerned with practical issues of implementation rather than d
 
 Here we set up enrollment, failure and dropout rates along with assumptions for enrollment duration and times of analyses.
 
+```{r, message=FALSE, warning=FALSE}
+library(gsdmvn)
+library(dplyr)
+library(tibble)
+library(gsDesign)
+library(gsDesign2)
+```
 
 ```{r}
 analysisTimes <- c(18, 24, 30, 36)
-enrollRates <- tibble::tibble(Stratum = "All",
-                              duration = c(2, 2, 2, 6),
-                              rate = c(8, 12, 16, 24))
-failRates <- tibble::tibble(Stratum = "All",
-                            duration=c(3,100),
-                            failRate=log(2)/c(8,14),
-                            hr=c(.9,.6),
-                            dropoutRate=.001
-                           )
+enrollRates <- tibble::tibble(
+  Stratum = "All",
+  duration = c(2, 2, 2, 6),
+  rate = c(8, 12, 16, 24)
+)
+failRates <- tibble::tibble(
+  Stratum = "All",
+  duration = c(3, 100),
+  failRate = log(2) / c(8, 14),
+  hr = c(.9, .6),
+  dropoutRate = .001
+)
 ```
 
 ## Deriving power for a given sample size
@@ -57,16 +61,16 @@ yy <- gs_info_ahr(enrollRates = enrollRates, failRates = failRates, events = Eve
 Now we can examine power using `gs_power_npe()`:
 
 ```{r}
-timing <- yy$info0/max(yy$info0)
-d <- gsDesign::gsDesign(k=length(timing), test.type=2, sfu= sfLDOF, alpha = .025, timing = timing)
-zz <- gs_power_npe(theta = yy$theta, info = yy$info, info0 = yy$info0, 
-             upper = gs_b, lower = gs_b,
-             upar = d$upper$bound,
-             lpar = d$lower$bound
+timing <- yy$info0 / max(yy$info0)
+d <- gsDesign::gsDesign(k = length(timing), test.type = 2, sfu = sfLDOF, alpha = .025, timing = timing)
+zz <- gs_power_npe(
+  theta = yy$theta, info = yy$info, info0 = yy$info0,
+  upper = gs_b, lower = gs_b,
+  upar = d$upper$bound,
+  lpar = d$lower$bound
 )
 zz
 ```
-
 
 ## Deriving sample size to power a trial
 
@@ -81,18 +85,21 @@ minx
 If we inflate the enrollment rates by `minx` and use a fixed design, we will see this achieves the targeted power.
 
 ```{r}
-gs_power_npe(theta = yy$theta[K], info = yy$info[K] * minx, info0 = yy$info0[K] * minx, 
-             upar = qnorm(.975), lpar = -Inf) %>% 
+gs_power_npe(
+  theta = yy$theta[K], info = yy$info[K] * minx, info0 = yy$info0[K] * minx,
+  upar = qnorm(.975), lpar = -Inf
+) %>%
   filter(Bound == "Upper")
 ```
 
 The power for a group sequential design with the same final sample size is a bit lower:
 
 ```{r}
-zz <- gs_power_npe(theta = yy$theta, info = yy$info * minx, info0 = yy$info0 * minx, 
-             upper = gs_spending_bound, lower = gs_spending_bound,
-             upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
-             lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
+zz <- gs_power_npe(
+  theta = yy$theta, info = yy$info * minx, info0 = yy$info0 * minx,
+  upper = gs_spending_bound, lower = gs_spending_bound,
+  upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
+  lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
 )
 zz
 ```
@@ -100,10 +107,11 @@ zz
 If we inflate this a bit we will be overpowered.
 
 ```{r}
-zz <- gs_power_npe(theta = yy$theta, info = yy$info * minx * 1.2, info0 = yy$info0 * minx * 1.2, 
-             upper = gs_spending_bound, lower = gs_spending_bound,
-             upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
-             lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
+zz <- gs_power_npe(
+  theta = yy$theta, info = yy$info * minx * 1.2, info0 = yy$info0 * minx * 1.2,
+  upper = gs_spending_bound, lower = gs_spending_bound,
+  upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
+  lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
 )
 zz
 ```
@@ -114,22 +122,23 @@ Now we use `gs_design_npe()` to inflate the information proportionately to power
 theta <- yy$theta
 info <- yy$info
 info0 <- yy$info0
-upper = gs_spending_bound
-lower = gs_spending_bound
-upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
-lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
-alpha = .025
-beta = .1
-binding = FALSE
-test_upper = TRUE
-test_lower = TRUE
-r = 18
-tol = 1e-06
+upper <- gs_spending_bound
+lower <- gs_spending_bound
+upar <- list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
+lpar <- list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
+alpha <- .025
+beta <- .1
+binding <- FALSE
+test_upper <- TRUE
+test_lower <- TRUE
+r <- 18
+tol <- 1e-06
 
-zz <- gs_design_npe(theta = yy$theta, info = yy$info, info0 = yy$info0, 
-             upper = gs_spending_bound, lower = gs_spending_bound,
-             upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
-             lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
+zz <- gs_design_npe(
+  theta = yy$theta, info = yy$info, info0 = yy$info0,
+  upper = gs_spending_bound, lower = gs_spending_bound,
+  upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL),
+  lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025, param = NULL, timing = NULL)
 )
 zz
 ```

--- a/vignettes/NPEbackground.Rmd
+++ b/vignettes/NPEbackground.Rmd
@@ -25,8 +25,7 @@ library(knitr)
 library(gsdmvn)
 ```
 
-# Overview
-
+## Overview
 
 The acronym NPES is short for non-proportional effect size. 
 While it is motivated primarily by a use for when designing a time-to-event trial under non-proportional hazards (NPH), we have simplified and generalized the concept here. The model is likely to be useful for rank-based survival tests beyond the logrank test that will be considered initially by @Tsiatis.
@@ -40,9 +39,9 @@ This vignettes addresses distribution theory and initial technical issues around
 This is then applied to generalize computational algorithms provided in Chapter 19 of @JTBook that are used to compute boundary crossing probabilities as well as boundaries for group sequential designs.
 Additional specifics around boundary computation, power and sample size are provided in a separate vignette.
 
-# The probability model
+## The probability model
 
-## The continuous model and E-process
+### The continuous model and E-process
 
 We consider a simple example here to motivate distribution theory that is quite general and applies across many situations.
 For instance @PLWBook immediately suggest paired observations, time-to-event and binary outcomes as endpoints where the theory is applicable.
@@ -70,7 +69,7 @@ $$ \mathcal{I}_k \equiv \frac{1}{\hbox{Var}(\hat\theta(t_k))} = n_k.$$
 We now see that $t_k$, $1\le k\le K$ is the so-called information fraction at analysis $k$ in that
 $t_k=\mathcal{I}_k/\mathcal{I}_K.$
 
-## Z-process
+### Z-process
 
 The Z-process is commonly used (e.g., @JTBook) and will be used below to extend the computational algorithm in Chapter 19 of @JTBook by defining equivalently in the first and second lines below for $k=1,\ldots,K$
 
@@ -82,7 +81,7 @@ and the expected value is
 
 $$E(Z_{k})= \sqrt{\mathcal{I}_k}\theta(t_{k})= \sqrt{n_k}E(\bar X_k) .$$
 
-## B-process
+### B-process
 
 B-values are mnemonic for Brownian motion.
 For $1\le k\le K$ we define
@@ -97,7 +96,7 @@ For our example, we have
 $$B_k=\frac{1}{\sqrt N}\sum_{i=1}^{n_k}X_i.$$
 It can be useful to think of $B_k$ as a sum of independent random variables.
 
-## Summary of E-, Z- and B-processes
+### Summary of E-, Z- and B-processes
 
 ```{r, message=FALSE, warning=FALSE, echo=FALSE}
 mt <- tibble::tribble(~Statistic,    ~Example,   ~"Expected value", ~Variance,
@@ -108,7 +107,7 @@ mt <- tibble::tribble(~Statistic,    ~Example,   ~"Expected value", ~Variance,
 mt %>% kable(escape=FALSE)
 ```
 
-## Conditional independence, covariance and canonical form
+### Conditional independence, covariance and canonical form
 
 We assume independent increments in the B-process.
 That is, for $1\le j < k\le K$
@@ -141,7 +140,7 @@ The independence of $B_j$ and
 $$B_k-B_j=\sum_{i=n_j + 1}^{n_k}X_i/(\sqrt N\sigma)$$
 is obvious for this example. 
 
-# Test bounds and crossing probabilities
+## Test bounds and crossing probabilities
 
 In this section we define notation for bounds and boundary crossing probabilities for a group sequential design.
 We also define an algorithm for computing bounds based on a targeted boundary crossing probability at each analysis.
@@ -152,7 +151,7 @@ For $k=1,2,\ldots,K-1$, interim cutoffs $-\infty \le a_k< b_k\le \infty$ are set
 An infinite efficacy bound at an analysis means that bound cannot be crossed at that analysis.
 Thus, $3K$ parameters define a group sequential design: $a_k$, $b_k$, and $\mathcal{I}_k$, $k=1,2,\ldots,K$. 
 
-## Notation for boundary crossing probabilities
+### Notation for boundary crossing probabilities
 
 We now apply the above distributional assumptions to compute boundary crossing probabilities.
 We use a shorthand notation in this section to have $\theta$ represent $\theta()$ and $\theta=0$ to represent $\theta(t)\equiv 0$ for all $t$.
@@ -173,7 +172,7 @@ Note that we can also set $a_k= -\infty$ for any or all analyses if a lower boun
 For $k<K$, we can set $b_k=\infty$ where an upper bound is not desired.
 Obviously, for each $k$, we want either $a_k>-\infty$ or $b_k<\infty$.
 
-## Recursive algorithms
+### Recursive algorithms
 
 We now provide a small update to the algorithm of Chapter 19 of @JTBook to do the numerical integration required to compute the boundary crossing probabilites of the previous section and also identifying group sequential boundaries satisfying desired characteristics. 
 The key to these calculations is the conditional power identitity in equation (1) above which allows building recursive numerical integration identities to enable simple, efficient numerical integration.
@@ -188,8 +187,8 @@ $$\begin{align}
 g_k(z; \theta) &= \frac{d}{dz}P_\theta(\{Z_k\le z\}\cap_{j=1}^{k-1}\{a_j\le Z_j<b_j\}) \\
  &=\int_{a_{k-1}}^{b_{k-1}}\frac{d}{dz}P_\theta(\{Z_k\le z |Z_{k-1}=z_{k-1}\})g_{k-1}(z_{k-1}; \theta)dz_{k-1}\\
  &=\int_{a_{k-1}}^{b_{k-1}}f_k(z_{k-1},z;\theta)g_{k-1}(z_{k-1}; \theta)dz_{k-1}.\tag{3}
- \end{align}
-$$
+ \end{align}$$
+
 The bottom line notation here is the same as on p. 347 in @JTBook.
 However, $f_k()$ here takes a slightly different form.
 
@@ -211,7 +210,7 @@ $$\alpha_{k}(\theta)=\int_{b_k}^\infty g_k(z;\theta)dz\tag{5}$$
 and
 $$\beta_{k}(\theta)=\int_{-\infty}^{a_k} g_k(z;\theta)dz.\tag{6}$$
 
-## Deriving spending boundaries
+### Deriving spending boundaries
 
 We can now derive boundaries satisfying given boundary crossing probabilities using equations (2-6) above.
 Suppose for we have specified $b_1,\ldots,b_{k-1}$ and $a_1,\ldots,a_{k-1}$ and now wish to derive $a_k$ and $b_k$ such that equations (5) and (6) hold.
@@ -236,17 +235,17 @@ $$b^{(0)} = \Phi^{-1}(1- \alpha_k(\theta)) + \sqrt{\mathcal{I}_k}\theta(t_k).\ta
 Normally, $b_k$ will be calculated with $\theta(t_k)=0$ for $k=1,2,\ldots,K$ which simplifies the above.
 However, $a_k$ computed analogously will often use a non-zero $\theta$ to enable so-called $\beta$-spending.
 
-# Numerical integration
+## Numerical integration
 
 The numerical integration required to compute boundary probabilities and derive boundaries is the same as that defined in section 19.3 of @JTBook. The single change is the replacement of the non-proportional effect size assumption of equation (3) above replacing the equivalent of equation (4) used for a constant effect size as in @JTBook.
 
-## Demonstrating calculations
+### Demonstrating calculations
 
 We walk through how to perform the basic calculations above.
 The basic scenario will have one interim analysis in addition to the final analysis.
 We will target Type I error $\alpha=0.025$ and Type II error $\beta = 0.1$, the latter corresponding to a target of 90% power.
 We will assume a power spending function with $\rho=2$ for both bounds.
-That is, for information fraction $t$, the cumulative spending will be $\alpha \time t^2$ for the upper bound and $\beta \times t^2$ for the lower bound.
+That is, for information fraction $t$, the cumulative spending will be $\alpha \times t^2$ for the upper bound and $\beta \times t^2$ for the lower bound.
 Statistical information will be 1 for the first analysis and 4 for the final analysis, leading to information fraction $t_1= 1/4, t_2=1$ for the interim and final, respectively.
 We assume $\theta_1 = .5$, $\theta_3=1.5$.
 
@@ -416,5 +415,4 @@ gs_power_npe(theta = theta, theta1 = theta, info = info, binding = TRUE,
 )
 ```
 
-
-# References
+## References

--- a/vignettes/NPEbounds.Rmd
+++ b/vignettes/NPEbounds.Rmd
@@ -1,7 +1,6 @@
 ---
 title: "Computing Bounds Under Non-Constant Treatment Effect"
 author: "Keaven Anderson"
-date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 bibliography: gsDesign.bib
 vignette: >
@@ -17,7 +16,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# Overview
+## Overview
 
 We consider one- and two-sided hypothesis testing using a group sequential design with possibly non-constant treatment effect.
 That can be useful for situations such as an assumed non-proportional hazards model or using weighted logrank tests for a time-to-event endpoint. 
@@ -58,7 +57,7 @@ We note that information may differ under different values of $\theta(t)$.
 For fixed designs, \cite{LachinBook} computes sample size based on different variances under the null and alternate hypothesis.
 
 
-# Two-sided testing and design
+## Two-sided testing and design
 
 We denote an alternative $H_{1}$: $\theta(t)=\theta_1(t)$; we will always assume $H_1$ for power calculations and sometimes will use $H_1$ for controlling lower boundary $a_k$ crossing probabilities. 
 A value of $\theta(t)>0$ will reflect a positive benefit. 
@@ -72,8 +71,7 @@ For $k=1,2,\ldots,K$, the trial is stopped at analysis $k$ to reject $H_0$ if $a
 If the trial continues until stage $k$ without crossing a bound and $Z_k\leq a_k$ then $H_1$ is rejected in favor of $H_0$, $k=1,2,\ldots,K$. 
 Note that if $a_K< b_K$ there is the possibility of completing the trial without rejecting $H_0$ or $H_1$. 
 
-
-## Haybittle-Peto and spending bounds
+### Haybittle-Peto and spending bounds
 
 The recursive algorithm of the previous section allows computation of both spending bounds and Haybittle-Peto bounds.
 For a Haybittle-Peto efficacy bound, one would normally set $b_k=\Phi^{-1}(1-\epsilon)$ for $k=1,2,\ldots,K-1$ and some small $\epsilon>0$ such as $\epsilon= 0.001$ which yields $b_k=3.09$.
@@ -85,7 +83,7 @@ As noted by @JTBook, $b_1,\ldots,b_K$ if determined under the null hypothesis de
 When computing bounds based on $\beta_k(\theta)$, $k=1,\ldots,K$,  where some $\theta(t_k)\neq 0$ we have an additional dependency with $a_k$ depending not only on $t_k$ and $b_k$, $k=1,\ldots,K$, but also on the final total information $\mathcal{I}_K$.
 Thus, a spending bound under something other than the null hypothesis needs to be recomputed each time $\mathcal{I}_K$ changes, whereas it only needs to be computed once when $\theta(t_k)=0$, $k=1,\ldots,K$.
 
-## Bounds based on boundary families
+### Bounds based on boundary families
 
 Assume constants $b_1^*,\ldots,b_K^*$ and a total targeted one-sided Type I error $\alpha$.
 We wish to find $C_u$ as a function of $t_1,\ldots t_K$ such that if $b_k=C_ub_k^*$ then $\alpha(0)=\alpha.$
@@ -99,11 +97,11 @@ For 2-sided symmetric bounds with $a_k=-b_k$, $k=1,\ldots,K$, we only need to so
 
 At this point, we do not solve for this type of bound for asymmetric upper and lower bounds.
 
-# Sample size
+## Sample size
 
 For sample size, we assume $t_k$, and $\theta(t_k)$ $1,\ldots,K$ are fixed. 
 We assume $\beta(\theta)$ is decreasing as $\mathcal{I}$ is decreasing.
 This will automatically be the case when $\theta(t_k)>0$, $k=1,\ldots,K$ and for many other cases.
 Thus, the information required is done by a search for $\mathcal{I_K}$ that yields $\alpha(\theta)$ yields the targeted power.
 
-# References
+## References

--- a/vignettes/PowerEvaluationWithSpending.Rmd
+++ b/vignettes/PowerEvaluationWithSpending.Rmd
@@ -15,16 +15,13 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
-library(gsdmvn)
 ```
-
 
 ## Overview
 
 This vignette covers how to compute power or Type I error for a design derived with a spending bound. 
 We will write this with a general non-constant treatment effect using `gs_design_npe()` to derived the design under one parameter setting and computing power under another setting.
 We will use a trial with a binary endpoint to enable a full illustration.
-
 
 ## Scenario for consideration
 
@@ -39,10 +36,9 @@ $$H_1: \theta = \theta_1= p_1^1 - p_2^1 = 0.15 - 0.10 = 0.05$$ and the null hypo
 $$H_0: \theta = \theta_0 = 0 = p_1^0 - p_2^0$$ where $p^0_1 = p^0_2= (p_1^1+p_2^1)/2 = 0.125$ 
 as laid out in @LachinBook. 
 
-
-
 ```{r}
 library(gsdmvn)
+
 p0 <- 0.15 # assumed failure rate in control group
 p1 <- 0.10 # assumed failure rate in experimental group
 alpha <- 0.025 # Design Type I error
@@ -114,6 +110,7 @@ Based on an input $p_1, p_2, \xi_1, \xi_2 = 1-\xi_1, n_k$ we will compute $\thet
 
 ```{r}
 library(tibble)
+
 gs_info_binomial <- function(p1, p2, xi1, n, delta = NULL){
   if (is.null(delta)) delta <- p1 - p2
   # Compute (constant) effect size at each analysis theta
@@ -138,9 +135,7 @@ gs_info_binomial <- function(p1, p2, xi1, n, delta = NULL){
 }
 ```
 
-
-For the CAPTURE trial, we have 
-
+For the CAPTURE trial, we have
 
 ```{r}
 h1 <- gs_info_binomial(p1 = .15, p2 = .1, xi1 = .5, n = c(350, 700, 1400))
@@ -177,4 +172,4 @@ gs_power_npe(theta = h$theta, theta1 = h$theta1, info = h$info,
 )
 ```
 
-# References
+## References

--- a/vignettes/QuickStart.Rmd
+++ b/vignettes/QuickStart.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# Overview
+## Overview
 
 We provide simple examples for use of the **gsdmvn** package for deriving fixed and group sequential designs under non-proportional hazards.
 The piecewise model for enrollment, failure rates, dropout rates and changing hazard ratio over time allow great flexibility in design assumptions. 
@@ -41,7 +41,7 @@ Topics included here are:
 All of these items are discussed briefly to enable a quick start for early adopters while also suggesting the ultimate possibilities that the software enables.
 Finally, while the final section provides current enhancement priorities, potential topic-related enhancements are discussed throughout the document.
 
-# Packages Used
+## Packages Used
 
 - The **gsdmvn** package is used here to implement group sequential distribution theory under non-proportional hazards and to derive a wide variety of boundary types for group sequential designs.
 - The **gsDesign** package is used as a check for results under proportional hazards as well as a source from deriving bounds using spending functions.
@@ -51,8 +51,7 @@ Finally, while the final section provides current enhancement priorities, potent
 The **gsdmvn** package will likely will likely be incorporated eventually into the **gsDesign2** package, resulting in a fully featured design package.
 However, features and implementation in **gsdmvn** will be allowed to change as needed during the agile rapid development phase.
 
-
-```{r setup, warning = FALSE}
+```{r, message=FALSE, warning=FALSE}
 library(gsdmvn)
 library(gsDesign)
 library(gsDesign2)
@@ -61,7 +60,7 @@ library(knitr)
 library(dplyr)
 ```
 
-# Enrollment Rates
+## Enrollment Rates
 
 Piecewise constant enrollment rates are input in a tabular format.
 Here we assume enrollment will ramp-up with 25%, 50%, and 75% of the final enrollment rate for 2 months each followed by a steady state 100% enrollment for another 6 months.
@@ -69,12 +68,11 @@ The rates will be increased later to power the design appropriately.
 However, the fixed enrollment rate periods will remain unchanged.
 
 ```{r}
-enrollRates <- tibble::tibble(Stratum = "All", duration = c(2, 2, 2, 6), rate = (1:4)/4)
+enrollRates <- tibble::tibble(Stratum = "All", duration = c(2, 2, 2, 6), rate = (1:4) / 4)
 enrollRates
 ```
 
-
-# Failure and Dropout Rates
+## Failure and Dropout Rates
 
 Constant failure and dropout rates are specified by study period and stratum; we consider a single stratum here.
 A hazard ratio is provided for treatment/control hazard rate for each period and stratum.
@@ -90,15 +88,17 @@ Finally, we assume a low 0.001 exponential dropout rate for both treatment group
 
 ```{r}
 medianSurv <- 12
-failRates = tibble::tibble(Stratum = "All",
-                           duration = c(4, Inf),
-                           failRate = log(2) / medianSurv,
-                           hr = c(1, .6),
-                           dropoutRate = .001)
+failRates <- tibble::tibble(
+  Stratum = "All",
+  duration = c(4, Inf),
+  failRate = log(2) / medianSurv,
+  hr = c(1, .6),
+  dropoutRate = .001
+)
 failRates
 ```
 
-# Fixed Design
+## Fixed Design
 
 Under the above enrollment, failure and dropout rate assumptions we now derive sample size for a trial targeted to complete in 36 months with no interim analysis, 90% power and 2.5% Type I error.
 The parameter `upar = qnorm(1 - .025)` in this case is the upper bound for the single analysis, while the parameter `beta = 0.1` is the Type II error (1 - power).
@@ -110,15 +110,16 @@ The design can be derived under these assumptions.
 # Type I error
 alpha <- .025
 design <-
-   gs_design_ahr(enrollRates = enrollRates,
-                 failRates = failRates,
-                 alpha = alpha,
-                 beta = .1, # Type II error = 1 - power
-                 analysisTimes = 36, # Planned trial duration
-                 IF = 1, # single analysis at information-fraction of 1
-                 upar = qnorm(1 - alpha), # Final analysis bound
-                 lpar = -Inf # No futility bound
-               )
+  gs_design_ahr(
+    enrollRates = enrollRates,
+    failRates = failRates,
+    alpha = alpha,
+    beta = .1, # Type II error = 1 - power
+    analysisTimes = 36, # Planned trial duration
+    IF = 1, # Single analysis at information-fraction of 1
+    upar = qnorm(1 - alpha), # Final analysis bound
+    lpar = -Inf # No futility bound
+  )
 ```
 
 There are three components to the resulting design.
@@ -142,13 +143,13 @@ The power is in the `Probability` column on the row with the `Upper` bound. The 
 The variables `info` and `info0` are statistical information at each analysis under the alternate and null hypothesis, respectively.
 
 ```{r,message=FALSE,warning=FALSE}
-design$bounds 
+design$bounds
 ```
 
 We note that the targeted `Events` are approximately what would be proposed with the @Schoenfeld1981 formula:
 
 ```{r}
-gsDesign::nEvents(hr=design$bounds$AHR)
+gsDesign::nEvents(hr = design$bounds$AHR)
 ```
 
 The difference is that `gs_design_ahr()` accounts for both a null and alternate hypothesis variance estimate for `theta=log(AHR)` at each analysis to yield a slightly more conservative event target due to slower accumulation of statistical information under the alternate hypothesis. See @LachinBook for this approach for fixed design; to our knowledge, this has not previously been extended to group sequential design. Due to simplicity, there may be reasons to allow approaches with a single variance estimate in future releases.
@@ -156,18 +157,19 @@ The difference is that `gs_design_ahr()` accounts for both a null and alternate 
 Finally, we note that with a shorter trial duration of 30 months, we need both a larger sample size and targeted number of events due to a larger expected AHR at the time of analysis:
 
 ```{r}
-gs_design_ahr(enrollRates = enrollRates,
-            failRates = failRates,
-            alpha = alpha,
-            beta = .1, # Type II error = 1 - power
-            analysisTimes = 30, # Planned trial duration
-            IF = 1, # single analysis at information-fraction of 1
-            upar = qnorm(1 - alpha), # Final analysis bound
-            lpar = -Inf # No futility bound
-          )$bounds %>% kable(digits=c(0,0,1,0,0,3,4,3,3,2,2))
+gs_design_ahr(
+  enrollRates = enrollRates,
+  failRates = failRates,
+  alpha = alpha,
+  beta = .1, # Type II error = 1 - power
+  analysisTimes = 30, # Planned trial duration
+  IF = 1, # single analysis at information-fraction of 1
+  upar = qnorm(1 - alpha), # Final analysis bound
+  lpar = -Inf # No futility bound
+)$bounds %>% kable(digits = c(0, 0, 1, 0, 0, 3, 4, 3, 3, 2, 2))
 ```
 
-# Group Sequential Design
+## Group Sequential Design
 
 We will not go into detail for group sequential designs here.
 In brief, however, a sequence of tests $Z_1, Z_2,\ldots, Z_K$ that follow a multivariate normal distribution are peformed to test if a new treatment is better than control @JTBook.
@@ -178,8 +180,7 @@ $$\alpha = 1 - P_0(\cap_{k=1}^K Z_k < b_k)$$
 Where $P_0()$ refers to a probability under the null hypothesis.
 This is referred to as a non-binding bound since it is assumed the trial will not be stopped early for futility if some $Z_k$ is small.
 
-## Simple Efficacy Bound Definition
-
+### Simple Efficacy Bound Definition
 
 @LanDeMets developed the spending function method for deriving group sequential bounds.
 This involves use of a non-decreasing spending function $f(t)$ for $t\ge 0$ where $f(0)=0$ and $f(t)=\alpha$ for $t \ge 1$.
@@ -194,36 +195,39 @@ Perhaps the most common spending function for this approach is the @LanDeMets ap
 $$f(t) = 2-2\Phi\left(\frac{\Phi^{-1}(1-\alpha/2)}{t^{1/2}}\right).$$
 
 ```{r, echo=FALSE, fig.width=6.5}
-t <- (0:50)/50
-plot(t, 2 - 2 * pnorm(qnorm(1-.0125)/sqrt(t)), type="l", ylab = "f(t)", xlab = "t")
+t <- (0:50) / 50
+plot(t, 2 - 2 * pnorm(qnorm(1 - .0125) / sqrt(t)), type = "l", ylab = "f(t)", xlab = "t")
 ```
 
 Suppose $K=3$ and $t_1=0.5$, $t_2 = 0.75$, $t_3 = 1$.
 We can define bounds with the **gsDesign** group sequential design function `gsDesign()` and Lan-DeMets O'Brien-Fleming spending function for $\alpha = 0.025$.
 
 ```{r}
-b <- gsDesign::gsDesign(k=3, timing = c(0.5, 0.75, 1), test.type=1, alpha = 0.025, sfu = gsDesign::sfLDOF)$upper$bound
+b <- gsDesign::gsDesign(k = 3, timing = c(0.5, 0.75, 1), test.type = 1, alpha = 0.025, sfu = gsDesign::sfLDOF)$upper$bound
 b
 ```
 
 Now we can define a one-sided group sequential design under the same enrollment, failure and dropout assumptions used previously.
 
 ```{r}
-design1s <- gs_design_ahr(enrollRates = enrollRates,
-                          failRates = failRates,
-                          analysisTimes = 36, # Trial duration
-                          upper = gs_spending_bound,
-                          upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
-                          lower = gs_b,
-                          lpar = rep(-Inf, 3), # No futility bound
-                          IF = c(.5, .75, 1)
-                        )
+design1s <- gs_design_ahr(
+  enrollRates = enrollRates,
+  failRates = failRates,
+  analysisTimes = 36, # Trial duration
+  upper = gs_spending_bound,
+  upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
+  lower = gs_b,
+  lpar = rep(-Inf, 3), # No futility bound
+  IF = c(.5, .75, 1)
+)
 ```
 
 Bounds at the 3 analyses are as follows; note that expected sample size at time of each data cutoff for analysis is also here in `N`. We filter on the upper bound so that lower bounds with `Z = -Inf` are not shown.
 
 ```{r}
-design1s$bounds %>% filter(Bound == "Upper") %>% kable(digits=c(0,0,1,0,0,3,4,3,3,2,2))
+design1s$bounds %>%
+  filter(Bound == "Upper") %>%
+  kable(digits = c(0, 0, 1, 0, 0, 3, 4, 3, 3, 2, 2))
 ```
 
 The boundary crossing probabilities column labeled `Probability` here are under the alternate hypothesis.
@@ -231,23 +235,23 @@ These are cumulative probabilities totaling 0.9 at the final analysis, represent
 If we wish to see the boundary probabilities under the null hypothesis, we can change the hazard ratio to 1 in the input `failRates`, use the output `enrollRates` from `designs` as follows.
 
 ```{r}
-gs_power_ahr(enrollRates = design1s$enrollRates,
-             failRates = design1s$failRates %>% mutate(hr = 1),
-             upper = gs_spending_bound,
-             upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
-             lpar = rep(-Inf, 3), # No futility bound
-             events = design1s$bound$Events[1:3]
-) %>% filter(Bound == "Upper") %>% kable(digits=c(0,0,1,0,0,3,4,3,3,2,2))
+gs_power_ahr(
+  enrollRates = design1s$enrollRates,
+  failRates = design1s$failRates %>% mutate(hr = 1),
+  upper = gs_spending_bound,
+  upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
+  lpar = rep(-Inf, 3), # No futility bound
+  events = design1s$bound$Events[1:3]
+) %>%
+  filter(Bound == "Upper") %>%
+  kable(digits = c(0, 0, 1, 0, 0, 3, 4, 3, 3, 2, 2))
 ```
 
-
-
-## Two-Sided Testing
+### Two-Sided Testing
 
 We will consider both symmetric and asymmetric 2-sided designs.
 
-
-### Symmetric 2-sided bounds
+#### Symmetric 2-sided bounds
 
 For a symmetric design, we can again define a bound using `gsDesign::gsDesign()`.
 For this example, the bound is identical to `b` above to the digits calculated.
@@ -257,38 +261,39 @@ b2 <- gsDesign::gsDesign(test.type = 2, sfu = sfLDOF, alpha = 0.025, timing = c(
 b2
 ```
 
-Now we replicate with 'gs_design_ahr()`:
-
+Now we replicate with `gs_design_ahr()`:
 
 ```{r}
-design2ss <- gs_design_ahr(enrollRates = enrollRates,
-                           failRates = failRates,
-                           analysisTimes = 36, # Trial duration
-                           IF = c(.5, .75, 1), # Information fraction at analyses
-                           upper = gs_spending_bound,
-                           upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
-                           lower = gs_spending_bound,
-                           lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
-                           h1_spending = FALSE
-                        )
+design2ss <- gs_design_ahr(
+  enrollRates = enrollRates,
+  failRates = failRates,
+  analysisTimes = 36, # Trial duration
+  IF = c(.5, .75, 1), # Information fraction at analyses
+  upper = gs_spending_bound,
+  upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
+  lower = gs_spending_bound,
+  lpar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
+  h1_spending = FALSE
+)
 ```
 
 
 Design bounds are confirmed with: 
 
 ```{r, message=FALSE}
-design2ss$bounds %>% kable(digits=c(0,0,1,0,0,3,4,3,3,2,2))
+design2ss$bounds %>% kable(digits = c(0, 0, 1, 0, 0, 3, 4, 3, 3, 2, 2))
 ```
 
 The bounds can be plotted easily:
 
 ```{r,fig.width=6.5}
-ggplot(data = design2ss$bound, aes(x=Events, y=Z, group = Bound)) + geom_line(aes(linetype=Bound)) + geom_point() +
+ggplot(data = design2ss$bound, aes(x = Events, y = Z, group = Bound)) +
+  geom_line(aes(linetype = Bound)) +
+  geom_point() +
   ggtitle("2-sided symmetric bounds with O'Brien-Fleming-like spending")
 ```
 
-
-### Asymmetric 2-sided bounds
+#### Asymmetric 2-sided bounds
 
 Asymmetric 2-sided designs are more common than symmetric since the objectives of the two bounds tend to be different.
 There is often caution to analyze early for efficacy or to use other than a conservative bound; both of these principles have been used with the example designs so far.
@@ -301,13 +306,14 @@ For efficacy, we add an infinite bound at this first interim analysis.
 b2sa <- c(Inf, b) # Same efficacy bound as before
 a2sa <- c(rep(qnorm(.05), 2), rep(-Inf, 2)) # Single futility analysis bound
 
-design2sa <- gs_design_nph(enrollRates = enrollRates,
-                        failRates = failRates,
-                        analysisTimes = 36, # Trial duration
-                        upper = gs_b, upar = b2sa,
-                        lower = gs_b, lpar = a2sa, # Asymmetric 2-sided bound
-                        IF = c(.3, .5, .75, 1)
-                        )
+design2sa <- gs_design_nph(
+  enrollRates = enrollRates,
+  failRates = failRates,
+  analysisTimes = 36, # Trial duration
+  upper = gs_b, upar = b2sa,
+  lower = gs_b, lpar = a2sa, # Asymmetric 2-sided bound
+  IF = c(.3, .5, .75, 1)
+)
 ```
 
 We now have a slightly larger sample size to account for the possibility of an early futility stop.
@@ -319,7 +325,9 @@ design2sa$enrollRates %>% summarise(N = ceiling(sum(rate * duration)))
 Bounds are now:
 
 ```{r}
-design2sa$bounds %>% filter(abs(Z) < Inf) %>% kable(digits=c(0,0,2,4,2,1,2,1,1,1))
+design2sa$bounds %>%
+  filter(abs(Z) < Inf) %>%
+  kable(digits = c(0, 0, 2, 4, 2, 1, 2, 1, 1, 1))
 ```
 
 We see that there does not need to be a (finite) stopping rule for each bound at each analysis.
@@ -332,17 +340,19 @@ This price is generally acceptable for regulatory acceptance and operational fle
 
 ```{r}
 events <- (design2sa$bounds %>% filter(Bound == "Upper"))$Events
-gs_power_nph(enrollRates = design1s$enrollRates,
-           failRates = design2sa$failRates %>% mutate(hr = 1),
-           upar = b2sa,
-           lpar = a2sa,
-           events = events,
-           maxEvents = max(events)) %>% 
-# filter eliminates bounds that are infinite
-  filter(abs(Z) < Inf)  %>% kable(digits=c(0,0,2,4,1,1,2,2,1,1))
+gs_power_nph(
+  enrollRates = design1s$enrollRates,
+  failRates = design2sa$failRates %>% mutate(hr = 1),
+  upar = b2sa,
+  lpar = a2sa,
+  events = events,
+  maxEvents = max(events)
+) %>%
+  # filter eliminates bounds that are infinite
+  filter(abs(Z) < Inf) %>% kable(digits = c(0, 0, 2, 4, 1, 1, 2, 2, 1, 1))
 ```
 
-# Confirmation by Simulation
+## Confirmation by Simulation
 
 We do a small simulation to approximate the boundary crossing probabilities just shown in the 2-sided asymmetric design `design2sa`.
 First, we generate test statistics for each analysis for a number of simulated trials.
@@ -351,21 +361,26 @@ First, we generate test statistics for each analysis for a number of simulated t
 fr <- simfix2simPWSurv(failRates = failRates)
 nsim <- 200 # Number of trial simulations
 simresult <- NULL
-N <- ceiling(design2sa$enrollRates %>% summarize(N = sum(rate/2 * duration)))*2
+N <- ceiling(design2sa$enrollRates %>% summarize(N = sum(rate / 2 * duration))) * 2
 K <- max(design2sa$bounds$Analysis)
 events <- ceiling(sort(unique(design2sa$bounds$Events)))
 
-for(i in 1:nsim){
-  sim <- simPWSurv(n = as.numeric(N),
-                   enrollRates = design2sa$enrollRates,
-                   failRates = fr$failRates,
-                   dropoutRates = fr$dropoutRates
-                  )
-  for(k in 1:K){
-    Z <- sim %>% cutDataAtCount(events[k]) %>% # cut simulation for analysis at targeted events
-         tensurv(txval = "Experimental") %>% tenFH(rg = tibble(rho = 0, gamma = 0))
-    simresult <- rbind(simresult,
-                       tibble(sim = i, k = k, Z = -Z$Z)) # Change sign for Z
+for (i in 1:nsim) {
+  sim <- simPWSurv(
+    n = as.numeric(N),
+    enrollRates = design2sa$enrollRates,
+    failRates = fr$failRates,
+    dropoutRates = fr$dropoutRates
+  )
+  for (k in 1:K) {
+    Z <- sim %>%
+      cutDataAtCount(events[k]) %>% # Cut simulation for analysis at targeted events
+      tensurv(txval = "Experimental") %>%
+      tenFH(rg = tibble(rho = 0, gamma = 0))
+    simresult <- rbind(
+      simresult,
+      tibble(sim = i, k = k, Z = -Z$Z) # Change sign for Z
+    )
   }
 }
 ```
@@ -373,19 +388,22 @@ for(i in 1:nsim){
 Now we analyze the individual trials and summarize results. A larger simulation would be required to more accurately assess the asymptotic approximation for boundary crossing probabilities.
 
 ```{r}
-bds <- tibble::tibble(k = sort(unique(design2sa$bounds$Analysis)),
-            upper = (design2sa$bounds %>% filter(Bound == "Upper"))$Z,
-            lower = (design2sa$bounds %>% filter(Bound == "Lower"))$Z
+bds <- tibble::tibble(
+  k = sort(unique(design2sa$bounds$Analysis)),
+  upper = (design2sa$bounds %>% filter(Bound == "Upper"))$Z,
+  lower = (design2sa$bounds %>% filter(Bound == "Lower"))$Z
 )
-trialsum <- simresult %>% 
-            full_join(bds, by = "k") %>%
-            filter(Z < lower | Z >= upper | k == K) %>%
-            group_by(sim) %>%
-            slice(1) %>% 
-            ungroup()
-trialsum %>% summarize(nsim = n(),
-                       "Early futility (%)" = 100 * mean(Z < lower),
-                       "Power (%)" = 100 * mean(Z >= upper))
+trialsum <- simresult %>%
+  full_join(bds, by = "k") %>%
+  filter(Z < lower | Z >= upper | k == K) %>%
+  group_by(sim) %>%
+  slice(1) %>%
+  ungroup()
+trialsum %>% summarize(
+  nsim = n(),
+  "Early futility (%)" = 100 * mean(Z < lower),
+  "Power (%)" = 100 * mean(Z >= upper)
+)
 ```
 
 ```{r}
@@ -393,45 +411,49 @@ xx <- trialsum %>% mutate(Positive = (Z >= upper))
 table(xx$k, xx$Positive)
 ```
 
-
-# Differences From **gsDesign**
+## Differences From **gsDesign**
 
 The sample size computation from the **gsdmvn** package is slightly different than from the **gsDesign** package for proportional hazards model.
 We demonstrate this with the bounds for the 1-sided test above under a proportional hazards model with an underlying hazard ratio of 0.7.
 
 ```{r}
-design1sPH <- gs_design_nph(enrollRates = enrollRates,
-                        failRates = failRates %>% mutate(hr = .7),
-                        analysisTimes = 36, # Trial duration
-                        upar = b,
-                        lpar = rep(-Inf, 3), # No futility bound
-                        IF = c(.5, .75, 1)
-                        )
+design1sPH <- gs_design_nph(
+  enrollRates = enrollRates,
+  failRates = failRates %>% mutate(hr = .7),
+  analysisTimes = 36, # Trial duration
+  upar = b,
+  lpar = rep(-Inf, 3), # No futility bound
+  IF = c(.5, .75, 1)
+)
 design1sPH$enrollRates %>% kable()
 ```
 
 This results in total sample size:
 
 ```{r}
-design1sPH$enrollRates %>% tail(1) %>% select(N)
+design1sPH$enrollRates %>%
+  tail(1) %>%
+  select(N)
 ```
 
 Now we derive a design with the same targeted properties using the **gsDesign** package.
 
 ```{r,warning=FALSE}
-x <- gsSurv(k = 3,
-            test.type = 1,
-            alpha = .025,
-            beta = .1,
-            timing = c(.5, .75, 1),
-            sfu = sfLDOF,
-            lambda = log(2) / medianSurv,
-            hr = .7, 
-            eta = .001, # dropout rate
-            gamma = c(.25, .5, .75, 1),
-            R = c(2, 2, 2, 6),
-            minfup = 24,
-            T = 36)
+x <- gsSurv(
+  k = 3,
+  test.type = 1,
+  alpha = .025,
+  beta = .1,
+  timing = c(.5, .75, 1),
+  sfu = sfLDOF,
+  lambda = log(2) / medianSurv,
+  hr = .7,
+  eta = .001, # Dropout rate
+  gamma = c(.25, .5, .75, 1),
+  R = c(2, 2, 2, 6),
+  minfup = 24,
+  T = 36
+)
 gsBoundSummary(x) %>% kable(row.names = FALSE)
 ```
 
@@ -441,6 +463,4 @@ Enrollment rates are:
 x$gamma %>% kable()
 ```
 
-
-
-# References
+## References

--- a/vignettes/SpendingTimeExamples.Rmd
+++ b/vignettes/SpendingTimeExamples.Rmd
@@ -1,7 +1,6 @@
 ---
 title: "Spending Time Examples"
 author: "Keaven Anderson"
-date: "`r Sys.Date()`"
 output:
   html_document:
     code_folding: hide
@@ -27,7 +26,7 @@ library(dplyr)
 library(gt)
 ```
 
-# Overview
+## Overview
 
 There are multiple scenarios where event-based spending for group sequential designs has limitations in terms of ensuring adequate follow-up and in ensuring adequate spending is preserved for the final analysis.
 Example contexts where this often arises is in trials where 
@@ -66,7 +65,7 @@ Code is available to unhide for those interested in implementation.
 Rather than bog down the conceptual discussion with implementation details, we have tried to provide sufficient comments in the code to guide implementation for those who are interested in that.
 
 
-# Delayed effect scenario 
+## Delayed effect scenario 
 
 
 We consider an example in a single stratum where there is a possibility of a delayed treatment effect.
@@ -90,7 +89,7 @@ failRates <- tibble(Stratum="All", duration = c(4, 100), hr = c(1, .6),
                     failRate = log(2) / m, dropoutRate = .001)
 ```
 
-# Fixed design, delayed effect
+## Fixed design, delayed effect
 
 
 ```{r}
@@ -126,9 +125,9 @@ xx <- gs_design_ahr(enrollRates,
 xx$bounds %>% table_fixed_design(enrollRates)
 ```
 
-## Power when assumptions design are wrong
+### Power when assumptions design are wrong
 
-### Scenario with less experimental benefit
+#### Scenario with less experimental benefit
 
 If we assume instead that the effect delay is 6 months instead of 4 and the control median is 10 months instead of 12,  there is a substantial impact on power.
 Here, we have assumed only the targeted events is required to do the final analysis resulting in an expected final analysis time of 25 months instead of the planned 30 and an average hazard ratio of 0.78 at the expected time of analysis rather than the targeted average hazard ratio of 0.70 under the original assumptions.
@@ -168,7 +167,7 @@ yy <-
 yy %>% table_fixed_design(xx$enrollRates)
 ```
 
-## Scenario with low control event rates
+### Scenario with low control event rates
 
 Now we assume a longer than planned control median, 16 months to demonstrate the value of retaining the event count requirement.
 If we analyze after 30 months, the power of the trial is 87% with 288 events expected.
@@ -207,15 +206,16 @@ yy <-
 )
 yy %>% table_fixed_design(xx$enrollRates)
 ```
-## Conclusions for fixed design
+
+### Conclusions for fixed design
 
 In summary, we have demonstrated the value of requiring both adequate events and adequate follow-up duration over an approach where the analysis is done with only one of these requirements.
 Requiring both will retain both power and important treatment benefit characterization over time when there is potential for delayed onset of a positive beneficial treatment effect.
 
 
-# Group sequential design
+## Group sequential design
 
-## Alternative spending strategies
+### Alternative spending strategies
 
 We extend the above design to detect a delayed effect to a group sequential design with a single interim analysis after 80% of the final planned events have accrued.
 We will assume the final analysis will require both the targeted trial duration and events based on the fixed design based on the evaluations above.
@@ -310,7 +310,7 @@ table_gs_design <- function(x, enrollRates, spending_time = NULL, max_info0 = NU
 ```
 
 
-## Planned design
+### Planned design
 
 We extend the design studied above to a group sequential design with a single interim analysis after 80% of the final planned events have accrued.
 We will assume the final analysis will require both the targeted trial duration and events based on the fixed design evaluations made above.
@@ -351,14 +351,15 @@ max_info0 <- max(xx$bounds$info0)
 planned_time <- planned_bounds$Time
 planned_bounds %>% table_gs_design(xx$enrollRates, max_info0 = max(xx$bounds$info0))
 ```
-## Two alternate approaches
+
+### Two alternate approaches
 
 We consider two alternate approaches to demonstrate the spending time concept that may be helpful in practice.
 However, skipping the following two subsections can be done if these are not of interest.
 The first demonstrates calendar spending as in @LanDeMets1989.
 The second is a basically the method of @FHO where a fixed incremental spend is used for a potentially variable number of interim analyses, with the final bound computed based on the unspent one-sided Type I error assigned to a hypothesis.
 
-### Calendar spending
+#### Calendar spending
 
 We use the same sample size as above, but change efficacy bound spending to calendar-based.
 The reason this spending is different than information-based spending is mainly due to the fact that the expected
@@ -379,7 +380,8 @@ yy <-
 actual_IF <- NULL # yy$info0 / max(yy$info0)
 yy %>% table_gs_design(xx$enrollRates, spending_time = upar_design_CF$timing, max_info0 = max(yy$info0))
 ```
-### Fixed incremental spend with a variable number of analyses
+
+#### Fixed incremental spend with a variable number of analyses
 
 As noted, this method was proposed by @FHO. 
 The general strategy demonstrated is to do an interim analses every 6 months until a both a final targeted follow-up time and cumulative number of events is achieved.
@@ -454,7 +456,7 @@ FHO %>%
   fmt_number(columns = "Nominal p", decimals = 4)
 ```
 
-## Less treatment effect scenario
+### Less treatment effect scenario
 
 As before, we compute power under the assumption of changing the median control group time-to-event to 10 months rather than the assumed 12 and the delay in effect onset is 6 months rather than 4.
 We otherwise do not change enrollment, dropout or hazard ratio assumptions.
@@ -502,7 +504,7 @@ yz <-
 yz %>% table_gs_design(xx$enrollRates, spending_time = planned_IF, max_info0 = max_info0)
 ```
 
-## Scenario with longer control median
+### Scenario with longer control median
 
 Now we return to the example where the control median is longer than expected to confirm that spending according to the planned level alone without considering the actual number of events will also result in a power reduction.
 While the power gain is not great (94.2% vs 95.0%) the interim and final p-value bounds are more aligned with the intent of emphasizing the final analysis where a smaller average hazard ratio is expected (0.680 vs 0.723 at the interim).
@@ -536,14 +538,14 @@ yz <-
 yz %>% table_gs_design(xx$enrollRates, spending_time = NULL, max_info0 = max_info0)
 ```
 
-## Summary for spending time motivation assuming delayed benefit
+### Summary for spending time motivation assuming delayed benefit
 
 In summary, using the minimum of planned and actual spending to adapt the design based on event-based spending adapts the interim bound to be more stringent than the final bound under different scenarios and ensures better power than event-based interim analysis and spending.
 
 
-# Testing multiple hypotheses
+## Testing multiple hypotheses
 
-## Assumptions
+### Assumptions
 
 We consider a simple case where we use the method of @MaurerBretz2013 to test both in the overall population and in a biomarker subgroup for the same endpoint.
 We assume an exponential failure rate with a median of 12 for the control group regardless of population.
@@ -565,8 +567,7 @@ We wish to ensure power for the biomarker positive group, but allow a good chanc
 If an alternative trial strategy is planned, an alternate approach to the following should be considered.
 In any case, we design first for the biomarker positive population with one-sided Type I error controlled at $\alpha = 0.0125$:
 
-
-## Planned design for biomarker positive population
+### Planned design for biomarker positive population
 
 ```{r}
 # Spending based on information fraction
@@ -607,8 +608,7 @@ positive_planned_bounds %>%
                   max_info0 = positive_max_info0)  
 ```
 
-
-## Planned design for overall population
+### Planned design for overall population
 
 We adjust the overall study enrollment rate to match the design requirement for the biomarker positive population.
 
@@ -660,7 +660,7 @@ overall_planned_bounds %>%
                   max_info0 = overall_max_info0)
 ```
 
-## Alternate scenarios overview
+### Alternate scenarios overview
 
 We divide our further evaluations into three subsections, one with a higher prevalence of biomarker positive patients than expected, one with a lower biomarker prevalence, followed by a section with differing event rate and hazard ratio assumptions.
 For each case, we will assume the total enrollment rate of `r round(sum(planned_enrollRates$rate),1)` per month as planned above.
@@ -691,9 +691,9 @@ upar_overall_actual_IF <- list(sf = gsDesign::sfLDOF,  param = NULL,
                                   max_info = overall_max_info0)
 ```
 
-## Biomarker subgroup prevalence higher than planned
+### Biomarker subgroup prevalence higher than planned
 
-### Biomarker subgroup power
+#### Biomarker subgroup power
 
 We suppose the biomarker prevalence is 60%, higher then the 50% prevalence the design anticipated.
 The enrollment rates by positive versus negative patients and expected enrollment duration are now:
@@ -727,8 +727,7 @@ positive_60_power %>%
                   max_info0 = positive_max_info0)
 ```
 
-
-### Overall population power
+#### Overall population power
 
 Now we use the same spending as above for the overall population, resulting in full $\alpha$-spending at the end of the trial even though the originally targeted events are not expected to be achieved.
 We note that the information fraction computed here is based on the originally planned events for the overall population.
@@ -765,7 +764,7 @@ gs_power_ahr(enrollRates = positive_60_enrollRates,
 xz %>% table_gs_design(enrollRates = positive_60_enrollRates, spending_time = NULL, max_info0 = overall_max_info0)
 ```
 
-## Biomarker subgroup prevalence lower than planned
+### Biomarker subgroup prevalence lower than planned
 
 We suppose the biomarker prevalence is 40%, lower than the 50% prevalence the design anticipated.
 The enrollment rates by positive versus negative patients and expected enrollment duration will now be:
@@ -779,8 +778,7 @@ positive_40_enrollRates$duration <- positive_planned_N / positive_40_enrollRates
 positive_40_enrollRates %>% gt() %>% fmt_number(columns = "rate", decimals=1)
 ```
 
-### Biomarker positive subgroup power
-
+#### Biomarker positive subgroup power
 
 Now we can compute the power for the biomarker positive group with the targeted events.
 
@@ -801,7 +799,7 @@ positive_40_power %>% filter(Bound == "Upper") %>%
                   max_info0 = positive_max_info0)
 ```
 
-### Overall population power
+#### Overall population power
 
 We see that by adapting the overall sample size and spending according to the biomarker subgroup, we retain 90% power.
 \In spite of the lower overall effect size, the larger adapted sample size ensures power retention.
@@ -820,8 +818,7 @@ gs_power_ahr(enrollRates = positive_40_enrollRates,
                   max_info0 = overall_max_info0)
 ```
 
-
-# Summary of findings
+## Summary of findings
 
 We suggested two overall findings when planning and executing a trial with a potentially delayed treatment effect:
 
@@ -842,7 +839,4 @@ Taking advantage of know correlations to ensure full $\alpha$ utilitization in m
 
 In summary, we have illustrated both the motivation and the illustration of the spending time approach through examples we have commonly encountered. Approaches suggested included an implementation of @FHO with a fixed incremental $\alpha$-spend at each interim analysis as well as the use of the minimum of planned and actual spending at interim analyses.
 
-
-# References
-
-  
+## References


### PR DESCRIPTION
This PR adds an extra level of hierarchy to the vignette headings (e.g. from h1 to h2) so that the floating TOC can be rendered correctly under > pkgdown 2.0.0.

Also enables Markdown for roxygen2 and ran roxygen2.