### PR TITLE
bug fix: large tau

### DIFF
--- a/R/gs_info_wlr.R
+++ b/R/gs_info_wlr.R
@@ -103,7 +103,7 @@ gs_delta_wlr <- function(arm0,
       term  <- ifelse(is.na(term), 0, term)
       weight(x, arm0, arm1) *  term * ( npsurvSS::hsurv(x, arm1) - npsurvSS::hsurv(x, arm0) )},
       lower=0,
-      upper= tmax, rel.tol = 1e-10)$value
+      upper= tmax, rel.tol = 1e-5)$value
 
 
   } else if (approx == "generalized schoenfeld") {


### PR DESCRIPTION
The issue in the example below is fixed. 

```
library(gsdmvn)
library(tibble)
# enrollment rate
enrollRates <- tibble(Stratum = "All", duration = 12, rate = 42)
# failure rate
failRates <- tibble(Stratum = "All",
                    duration = c(6, 100),
                    failRate = log(2) / 15,
                    hr = c(1, .6),
                    dropoutRate = 0.001)
# randomization ratio (exp : ctl)
ratio <- 1
# study duration (enrollment + min follow up)
trial_duration <- 28
# weight in WLR
weight <- function(x, arm0, arm1){gsdmvn:::wlr_weight_fh(x, arm0, arm1, rho = -1, gamma = 0, tau = 20)}
# create Arm object
gs_arm <- gs_create_arm(enrollRates, failRates, ratio)
arm0 <- gs_arm$arm0
arm1 <- gs_arm$arm1
# calculate delta
gs_delta_wlr(arm0, arm1, tmax = trial_duration, weight = weight, approx = "asymptotic")
```