### PR TITLE
gs_info_wlr: fix AHR calculation

### DIFF
--- a/R/gs_info_wlr.R
+++ b/R/gs_info_wlr.R
@@ -122,7 +122,7 @@ gs_delta_wlr <- function(arm0,
         ( p0 * prob_risk(arm0, x, tmax) + p1 * prob_risk(arm1, x, tmax) )^2 *
         ( p0 * dens_event(arm0, x, tmax) + p1 * dens_event(arm1, x, tmax))},
       lower=0,
-      upper= tmax)$valu
+      upper= tmax)$value
   } else {
 
     stop("gs_delta_wlr(): Please specify a valid approximation for the mean.", call.=F)
@@ -262,8 +262,8 @@ gs_info_wlr <- function(enrollRates=tibble::tibble(Stratum="All",
     p_event[i]      <- p0 * prob_event.arm(arm0, tmax = t) + p1 * prob_event.arm(arm1, tmax = t)
     p_subject[i]    <- p0 * npsurvSS::paccr(t, arm0) + p1 * npsurvSS::paccr(t, arm1)
     delta[i]        <- gs_delta_wlr(arm0, arm1, tmax = t, weight = weight, approx = approx)
-    log_ahr[i]          <- delta[i] / gs_delta_wlr(arm0, arm1, tmax = t, weight = weight,
-                                                   approx = "generalized schoenfeld", normalization = TRUE)
+    # log_ahr[i]          <- delta[i] / gs_delta_wlr(arm0, arm1, tmax = t, weight = weight,
+    #                                                approx = "generalized schoenfeld", normalization = TRUE)
     sigma2_h1[i]    <- gs_sigma2_wlr(arm0, arm1, tmax = t, weight = weight, approx = approx)
     sigma2_h0[i]    <- gs_sigma2_wlr(arm_null, arm_null, tmax = t, weight = weight, approx = approx)
   }
@@ -274,7 +274,7 @@ gs_info_wlr <- function(enrollRates=tibble::tibble(Stratum="All",
              Time = time,
              N = N,
              Events = avehr$Events,
-             AHR = exp(log_ahr),
+             AHR = avehr$AHR,
              delta = delta,
              sigma2 = sigma2_h1,
              theta = theta,

--- a/tests/testthat/test-independent_test_gs_info_wlr.R
+++ b/tests/testthat/test-independent_test_gs_info_wlr.R
@@ -61,21 +61,25 @@ test_that("Validate the function based on examples with individual functions",{
   
   evt01 <- gsdmvn:::prob_event.arm(arm0, tmax = analysisTimes) * n0 +
     gsdmvn:::prob_event.arm(arm1, tmax = analysisTimes) * n1
-  log_ahr <- sapply(analysisTimes, function(t_k) {
-    gsdmvn:::gs_delta_wlr(arm0, arm1, tmax = t_k, weight = weight) /
-      gsdmvn:::gs_delta_wlr(
-        arm0, arm1,
-        tmax = t_k,
-        weight = weight,
-        approx = "generalized schoenfeld",
-        normalization = TRUE
-      )
-  })
+  # log_ahr <- sapply(analysisTimes, function(t_k) {
+  #   gsdmvn:::gs_delta_wlr(arm0, arm1, tmax = t_k, weight = weight) /
+  #     gsdmvn:::gs_delta_wlr(
+  #       arm0, arm1,
+  #       tmax = t_k,
+  #       weight = weight,
+  #       approx = "generalized schoenfeld",
+  #       normalization = TRUE
+  #     )
+  # })
+  
+  avehr <- gsDesign2::AHR(enrollRates = enrollRates, failRates = failRates, ratio = ratio,
+                          totalDuration = analysisTimes)
   
   #FH(0,1)
   expect_equal(object = as.numeric(fh01$N), expected = rep(N01,3), tolerance = 1)
   expect_equal(object = as.numeric(fh01$Events), expected = evt01, tolerance = 1)
-  expect_equal(object = as.numeric(fh01$AHR), expected = exp(log_ahr), tolerance = .025)
+  #expect_equal(object = as.numeric(fh01$AHR), expected = exp(log_ahr), tolerance = .025)
+  expect_equal(object = as.numeric(fh01$AHR), expected = avehr$AHR, tolerance = .025)
   expect_equal(object = as.numeric(fh01$delta), expected = -delta01, tolerance = .01)
   expect_equal(object = as.numeric(fh01$sigma2), expected = sigma201, tolerance = .01)
   expect_equal(object = as.numeric(fh01$theta), expected = theta01, tolerance = .2)


### PR DESCRIPTION
Fix the calculation of AHR. Now the evaluation is the same as `gs_info_ahr` for imbalanced design. 

## Example code: 

```
library(dplyr)
library(gsDesign2)
devtools::load_all()

enrollRates<-tibble::tibble(Stratum="All",duration=6,rate=1)

failRates<-tibble::tibble(Stratum="All",period=1:2,duration=c(4,20),
                          failRate=c(0.05,0.2)/12,
                          hr=c(0.75, 0.5),
                          dropoutRate=c(0.1,0.2)/12)



studyDuration<-sum(failRates$duration)

W1<-gs_design_wlr(enrollRates = enrollRates,
                  failRates = failRates,
                  analysisTimes = studyDuration,
                  ratio=1,
                  upar = qnorm(.975),
                  lpar = qnorm(.975))$bounds 


W2<-gs_design_wlr(enrollRates = enrollRates,
                  failRates = failRates,
                  analysisTimes = studyDuration,
                  ratio=2,
                  upar = qnorm(.975),
                  lpar = qnorm(.975))$bounds 
```

## Output: 

```
> W1
# A tibble: 1 × 11
  Analysis Bound  Time     N Events     Z Probability   AHR theta  info info0
     <dbl> <chr> <dbl> <dbl>  <dbl> <dbl>       <dbl> <dbl> <dbl> <dbl> <dbl>
1        1 Upper    24  586.   101.  1.96         0.9 0.517 0.644  25.1  25.4
> W2
# A tibble: 1 × 11
  Analysis Bound  Time     N Events     Z Probability   AHR theta  info info0
     <dbl> <chr> <dbl> <dbl>  <dbl> <dbl>       <dbl> <dbl> <dbl> <dbl> <dbl>
1        1 Upper    24  517.   80.4  1.96         0.9 0.518 0.720  17.5  22.5
```